### PR TITLE
check if radius and limit are numbers

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -72,6 +72,10 @@ RegisterCommand("speedzone", function(source, args)
     if not args[1] or not args[2] then
         TriggerEvent('QBCore:Notify', "/speedzone [radius] [limit in kmh]")
     else
+        if not tonumber(args[1]) or not tonumber(args[2]) then
+            TriggerEvent('QBCore:Notify', "You have to enter valid numbers", "error")
+            return
+        end
         gKmh = KMPHtoMPS(tonumber(args[2]))
         
         gPos = GetEntityCoords(PlayerPedId())        


### PR DESCRIPTION
adds a tonumber() check to argument 1 and 2 in the /speedzone command + returns command and sends message if those arguments are not numbers. didn't test it but should work